### PR TITLE
chore: redirect the login button to the home screen without authentication checks

### DIFF
--- a/lib/sign_in/view/widgets/login_button.dart
+++ b/lib/sign_in/view/widgets/login_button.dart
@@ -1,9 +1,12 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:formz/formz.dart';
 import 'package:fpb/core/application/email_password_bloc/email_password_bloc.dart';
+import 'package:fpb/core/domain/user.dart';
 import 'package:fpb/core/presentation/widget/fpb_button.dart';
 import 'package:fpb/l10n/l10n.dart';
+import 'package:fpb/router/app_route.gr.dart';
 
 class LoginButton extends StatelessWidget {
   const LoginButton({
@@ -13,17 +16,24 @@ class LoginButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
+
+    /// TODO: Remove after general app UI validation
+    final User user = User(id: 'BZHyLm22EUai8ISKY43RBjMyjPB3', isNewUser: false, photo: 'https://lh3.googleusercontent.com/a/AGNmyxZqAyvq47qEAmNuIlrG3kc3pAVurxcFBZ3gAdTIEf4=s96-c', providerId: '', name: 'Amanda Shafack,', email: 'shafack.likhene@gmail.com', phoneNumber: '');
+
     return BlocBuilder<EmailPasswordBloc, EmailPasswordState>(
       buildWhen: (previous, current) => previous.status != current.status,
       builder: (context, state) {
-        return FormzStatus.submissionInProgress == state.status
-            ? const FpbButton(label: 'Log in', onTap: null)
-            : FpbButton(
-                label: l10n.signInLogInButtonLabel,
-                onTap: () => context
-                    .read<EmailPasswordBloc>()
-                    .add(const EmailPasswordEvent.submitted()),
-              );
+        // return FormzStatus.submissionInProgress == state.status
+        //     ?  FpbButton(label: 'Log in', onTap: null)
+        //     : FpbButton(
+        //         label: l10n.signInLogInButtonLabel,
+        //         onTap: () => context
+        //             .read<EmailPasswordBloc>()
+        //             .add(const EmailPasswordEvent.submitted()),
+        //       );
+
+        /// TODO Short circuit Login button, remove after general app UI validation
+        return FpbButton(label: 'Log in', onTap: (){context.router.push(HomeRouter(user: user ));});
       },
     );
   }


### PR DESCRIPTION
## Description
The implemented authentication features do not work in production.
Link the login button to the home screen without valid authentication checks to validate the UIs within the app.



## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read and ran all relevant commands as specififed in the Running Tests section of the [Contributor Guide].
- [ ] The title of the PR follows the [Conventional Commits] guideline
- [ ] My local branch follows the naming standards in the [Deepsource Branch Naming Convention] or [Biodiversity Branch Naming Convention]
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy],
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.


[Contributor Guide]: https://github.com/FlutterPlaza/.github/blob/main/CONTRIBUTING.md
[Conventional Commits]: https://www.conventionalcommits.org/en/v1.0.0-beta.4/
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[Biodiversity Branch Naming Convention]: https://bit.ly/3DyYSwM
[Deepsource Branch Naming Convention]: https://bit.ly/3Y08Gs4