### PR TITLE
fix: back button leading to flutter splash from (onboarding screen, auth screens and home screen)

### DIFF
--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:fpb/app/view/app_event_watcher.dart';
 import 'package:fpb/authentication_mock_without_backend/application/bloc/authentication_bloc.dart';
 import 'package:fpb/authentication_with_firebase/application/bloc/auth_bloc.dart';
 import 'package:fpb/core/application/internet_and_time_bloc/internet_and_time_bloc.dart';
@@ -30,16 +31,22 @@ class App extends StatelessWidget {
       child: LayoutBuilder(
         builder: (context, cts) {
           return MaterialApp.router(
-              title: 'FinFlow',
-              theme: whiteTheme(context, cts),
-              localizationsDelegates: AppLocalizations.localizationsDelegates,
-              supportedLocales: AppLocalizations.supportedLocales,
-              routeInformationParser: appRouter.defaultRouteParser(),
-              routerDelegate: appRouter.delegate(
-                navigatorObservers: () => [
-                  HeroController(),
-                ],
-              ));
+            title: 'FinFlow',
+            theme: whiteTheme(context, cts),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            routeInformationParser: appRouter.defaultRouteParser(),
+            routerDelegate: appRouter.delegate(
+              navigatorObservers: () => [
+                HeroController(),
+              ],
+            ),
+            builder: (context, child) {
+              return AppEventWatcher(
+                child: child!,
+              );
+            },
+          );
         },
       ),
     );

--- a/lib/app/view/app_event_watcher.dart
+++ b/lib/app/view/app_event_watcher.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:fpb/app/view/app.dart';
+import 'package:fpb/authentication_with_firebase/application/bloc/auth_bloc.dart';
+import 'package:fpb/core/application/internet_and_time_bloc/internet_and_time_bloc.dart';
+import 'package:fpb/core/settings/cached.dart';
+import 'package:fpb/injection.dart';
+import 'package:fpb/router/app_route.gr.dart';
+
+class AppEventWatcher extends StatelessWidget {
+  final Widget child;
+  const AppEventWatcher({
+    super.key,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiBlocListener(
+      listeners: [
+        BlocListener<InternetAndTimeBloc, InternetAndTimeState>(
+          listenWhen: (p, c) => !c.isConnected || !c.isTimeSynced,
+          listener: (context, state) {
+            if (!state.isConnected) {
+              // _alertNoInternetDetected(context);
+            }
+            if (!state.isTimeSynced) {
+              // _alertTimeNotSyncedDetected(context);
+            }
+          },
+        ),
+        BlocListener<AuthBloc, AuthState>(
+          listener: (context, state) {
+            state.map(
+              splash: (_) {},
+              authenticated: (_) {
+                appRouter.replace(HomeRouter(user: _.user));
+              },
+              unauthenticated: (_) {
+                final cached = getIt<Cached>();
+                if (cached.firstTimeUser) {
+                  cached.firstTimeUser = false;
+                  appRouter.replace(OnboardingRoute());
+                } else {
+                  appRouter.replace(SignInRoute());
+                }
+              },
+            );
+          },
+        ),
+      ],
+      child: child,
+    );
+  }
+}

--- a/lib/authentication_with_firebase/application/bloc/auth_bloc.dart
+++ b/lib/authentication_with_firebase/application/bloc/auth_bloc.dart
@@ -6,9 +6,9 @@ import 'package:fpb/core/domain/user.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:injectable/injectable.dart';
 
+part 'auth_bloc.freezed.dart';
 part 'auth_event.dart';
 part 'auth_state.dart';
-part 'auth_bloc.freezed.dart';
 
 @injectable
 @singleton
@@ -34,9 +34,9 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
   late final StreamSubscription<User> _userSubscription;
 
   void _triggerAuth(_TriggerAuth event, Emitter<AuthState> emit) {
-    _authFacade.currentUser == User.empty
+    emit(_authFacade.currentUser == User.empty
         ? AuthState.unauthenticated()
-        : AuthState.authenticated(user: _authFacade.currentUser);
+        : AuthState.authenticated(user: _authFacade.currentUser));
   }
 
   void _authenticated(_UserChanged event, Emitter<AuthState> emit) {

--- a/lib/onboarding/view/splash_screen.dart
+++ b/lib/onboarding/view/splash_screen.dart
@@ -1,58 +1,15 @@
 // a stateless widget that shows the splash screen with a logo and a text
-import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:fpb/authentication_with_firebase/application/bloc/auth_bloc.dart';
-import 'package:fpb/core/application/internet_and_time_bloc/internet_and_time_bloc.dart';
-import 'package:fpb/core/settings/cached.dart';
-import 'package:fpb/injection.dart';
-import 'package:fpb/router/app_route.gr.dart';
 
 class SplashScreen extends StatelessWidget {
   const SplashScreen({super.key});
   static const routeName = '/';
   @override
   Widget build(BuildContext context) {
-    final cached = getIt<Cached>();
-    return MultiBlocListener(
-      listeners: [
-        BlocListener<InternetAndTimeBloc, InternetAndTimeState>(
-          listenWhen: (p, c) => !c.isConnected || !c.isTimeSynced,
-          listener: (context, state) {
-            if (!state.isConnected) {
-              // _alertNoInternetDetected(context);
-            }
-            if (!state.isTimeSynced) {
-              // _alertTimeNotSyncedDetected(context);
-            }
-          },
-        ),
-        BlocListener<AuthBloc, AuthState>(
-          listener: (context, state) {
-            state.map(
-              splash: (_) {},
-              authenticated: (_) {
-                context.router.popUntil((route) => route.isFirst);
-                context.router.push(HomeRouter(user: _.user));
-              },
-              unauthenticated: (_) {
-                context.router.popUntil((route) => route.isFirst);
-                if (cached.firstTimeUser) {
-                  cached.firstTimeUser = false;
-                  context.router.push(OnboardingRoute());
-                } else {
-                  context.router.push(SignInRoute());
-                }
-              },
-            );
-          },
-        ),
-      ],
-      child: const Scaffold(
-        resizeToAvoidBottomInset: false,
-        body: Center(
-          child: CircularProgressIndicator(),
-        ),
+    return const Scaffold(
+      resizeToAvoidBottomInset: false,
+      body: Center(
+        child: CircularProgressIndicator(),
       ),
     );
   }


### PR DESCRIPTION
## Description
- fixed back button leading to flutter splashscreen .
- added an app event watcher widget that listens to Auth events and react accordingly (removed it from the splashscreen)
## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read and ran all relevant commands as specififed in the Running Tests section of the [Contributor Guide].
- [ ] The title of the PR follows the [Conventional Commits] guideline
- [ ] My local branch follows the naming standards in the [Deepsource Branch Naming Convention] or [Biodiversity Branch Naming Convention]
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy],
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.


[Contributor Guide]: https://github.com/FlutterPlaza/.github/blob/main/CONTRIBUTING.md
[Conventional Commits]: https://www.conventionalcommits.org/en/v1.0.0-beta.4/
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[Biodiversity Branch Naming Convention]: https://bit.ly/3DyYSwM
[Deepsource Branch Naming Convention]: https://bit.ly/3Y08Gs4